### PR TITLE
remove "using strict";

### DIFF
--- a/scripts/game.js
+++ b/scripts/game.js
@@ -64,8 +64,6 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-"use strict";
-
 // Require will call this with GameServer, GameSupport, and Misc once
 // gameserver.js, gamesupport.js, and misc.js have loaded.
 


### PR DESCRIPTION
The issue is when in strict mode setting `element.style = "string";` does not
work in Chrome or Safari. Both generate an error about accessing read only
value or trying to set something with only a getter. Removing the "using strict"
fixes it.

I have no idea if that's a bug in Firefox not being strict enough or a bug in
Chrome and Safari being too strict. [Asked on SO](http://stackoverflow.com/questions/32468352/uncaught-typeerror-cannot-set-property-style-of-htmlelement-which-has-only-a).
